### PR TITLE
Add Option To Create Typescript Declaration File

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ pixi-spritesheet-generator *.png
 
 Also, the following options can be passed:
 
-| Option        | Description                                                                                                                                        | Default Value |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| -o, --output  | The path to the directory where the spritesheet and data file will be saved.                                                                       | process.cwd() |
-| -t, --trim    | Indicates whether transparent whitespace around the sprites should be trimmed or not. Note that trimming still needs some work and might be buggy. | false         |
-| -c, --columns | The number of columns in the spritesheet. If not provided, the spritesheet will be a single column.                                                | 1             |
+| Option            | Description                                                                                                                                                          | Default Value |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| -o, --output      | The path to the directory where the spritesheet and data file will be saved.                                                                                         | process.cwd() |
+| -t, --trim        | Indicates whether transparent whitespace around the sprites should be trimmed or not. Note that trimming still needs some work and might be buggy.                   | false         |
+| -c, --columns     | The number of columns in the spritesheet. If not provided, the spritesheet will be a single column.                                                                  | 1             |
+| -d, --declaration | Indicates whether a types file should be generated or not. These types include the values of the spritesheet and separate union types of the sprites and animations. | false         |
 
 To use the spritesheet in Pixi, see the [Pixi Spritesheet Documentation](https://pixijs.download/dev/docs/PIXI.Spritesheet.html).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pixi-spritesheet-generator",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Generate a spritesheet with a png and a JSON data file from a set of individual sprites that can be used with PixiJS",
     "keywords": [
         "pixijs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ program
     )
     .option(
         "-d, --declaration",
-        "Indicates whether a types file should be generated or not. These types are union types of the sprites and animations.",
+        "Indicates whether a types file should be generated or not. These types include the values of the spritesheet and separate union types of the sprites and animations.",
         false,
     )
     .action(async (input, options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,11 @@ program
         "The number of columns in the spritesheet. If not provided, the spritesheet will be a single column.",
         "1",
     )
+    .option(
+        "-d, --declaration",
+        "Indicates whether a types file should be generated or not. These types are union types of the sprites and animations.",
+        false,
+    )
     .action(async (input, options) => {
         const spinner = ora({ stream: process.stdout });
 
@@ -287,6 +292,30 @@ program
             JSON.stringify(jsonData, null, 4),
             "utf-8",
         );
+
+        if (options.declaration) {
+            spinner.text = "Creating TypeScript types...";
+
+            const typesData = `\
+    export type Sprite = ${Object.keys(jsonData.frames)
+        .map((frame) => `"${frame}"`)
+        .join(" | ")}
+
+    export type Animation = ${Object.keys(animations)
+        .map((animation) => `"${animation}"`)
+        .join(" | ")};
+
+    export type SpritesheetData = {
+    meta: ${JSON.stringify(jsonData.meta, null, 4)};
+    frames: ${JSON.stringify(jsonData.frames, null, 4)};
+    animations: ${JSON.stringify(animations, null, 4)};
+}`;
+            await fsPromises.writeFile(
+                path.join(options.output, `${name}.d.ts`),
+                typesData,
+                "utf-8",
+            );
+        }
 
         if (options.trim) await rimraf(trimmedSpritesDir);
 


### PR DESCRIPTION
- Added an option `-d, --declaration` to create a `.d.ts` file with the exact values of the spritesheet data file along with union types of the sprite names and animations.