### PR TITLE
Remove Path Name From Sprites + Trimmed Sprites Hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pixi-spritesheet-generator",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "description": "Generate a spritesheet with a png and a JSON data file from a set of individual sprites that can be used with PixiJS",
     "keywords": [
         "pixijs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,10 +158,12 @@ program
                 xOffset += spriteDimensions.width;
             }
 
+            const spriteNameParsed = path.parse(inputFile);
+
             // Next, we create the `animations` section of the data file.
             // First, we get the name of the sprite without the extension by
             // splitting on common delimiters (hyphens, underscores, and spaces).
-            const spriteNameNoExtension = path.parse(inputFile).name;
+            const spriteNameNoExtension = spriteNameParsed.name;
             const spriteNameSplit = spriteNameNoExtension.split(/(?:-|_| )+/g);
 
             if (spriteNameSplit.length) {
@@ -190,11 +192,13 @@ program
                         // `animations` object, we create one. Otherwise, we
                         // add the sprite to the existing entry.
                         if (!spriteHasAnimationEntry) {
-                            animations[spriteAnimationName] = [inputFile];
+                            animations[spriteAnimationName] = [
+                                spriteNameParsed.base,
+                            ];
                         } else {
                             animations[spriteAnimationName] = [
                                 ...animations[spriteAnimationName],
-                                inputFile,
+                                spriteNameParsed.base,
                             ];
                         }
                     }
@@ -204,7 +208,7 @@ program
             return {
                 x,
                 y,
-                name: inputFile,
+                name: spriteNameParsed.base,
                 width: spriteDimensions.width,
                 height: spriteDimensions.height,
             };
@@ -297,18 +301,18 @@ program
             spinner.text = "Creating TypeScript types...";
 
             const typesData = `\
-    export type Sprite = ${Object.keys(jsonData.frames)
-        .map((frame) => `"${frame}"`)
-        .join(" | ")}
+export type Sprite = ${Object.keys(jsonData.frames)
+                .map((frame) => `"${frame}"`)
+                .join(" | ")}
 
-    export type Animation = ${Object.keys(animations)
-        .map((animation) => `"${animation}"`)
-        .join(" | ")};
+export type Animation = ${Object.keys(animations)
+                .map((animation) => `"${animation}"`)
+                .join(" | ")};
 
-    export type SpritesheetData = {
-    meta: ${JSON.stringify(jsonData.meta, null, 4)};
-    frames: ${JSON.stringify(jsonData.frames, null, 4)};
-    animations: ${JSON.stringify(animations, null, 4)};
+export type SpritesheetData = {
+    meta: ${JSON.stringify(jsonData.meta, null, 8)};
+    frames: ${JSON.stringify(jsonData.frames, null, 8)};
+    animations: ${JSON.stringify(animations, null, 8)};
 }`;
             await fsPromises.writeFile(
                 path.join(options.output, `${name}.d.ts`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ program
         const spritePlacement = filesToUse.map((inputFile) => {
             const spriteNameParsed = path.parse(inputFile);
 
-            spinner.text = `Getting sprite position, dimensions, and animations for ${spriteNameParsed.base}...`;
+            spinner.text = `Getting sprite position, dimensions, and animations for ${spriteNameParsed.name}...`;
             spinner.render();
 
             const spriteDimensions = getImageDimensions(inputFile);
@@ -218,12 +218,12 @@ program
                         // add the sprite to the existing entry.
                         if (!spriteHasAnimationEntry) {
                             animations[spriteAnimationName] = [
-                                spriteNameParsed.base,
+                                spriteNameParsed.name,
                             ];
                         } else {
                             animations[spriteAnimationName] = [
                                 ...animations[spriteAnimationName],
-                                spriteNameParsed.base,
+                                spriteNameParsed.name,
                             ];
                         }
                     }
@@ -233,7 +233,7 @@ program
             return {
                 x,
                 y,
-                name: spriteNameParsed.base,
+                name: spriteNameParsed.name,
                 width: spriteDimensions.width,
                 height: spriteDimensions.height,
             };

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,9 @@ program
         const animations: { [key: string]: string[] } = {};
 
         const spritePlacement = input.map((inputFile) => {
-            spinner.text = `Getting sprite position, dimensions, and animations for ${inputFile}...`;
+            const spriteNameParsed = path.parse(inputFile);
+
+            spinner.text = `Getting sprite position, dimensions, and animations for ${spriteNameParsed.base}...`;
             spinner.render();
 
             const spriteDimensions = getImageDimensions(inputFile);
@@ -157,8 +159,6 @@ program
                 // to the row.
                 xOffset += spriteDimensions.width;
             }
-
-            const spriteNameParsed = path.parse(inputFile);
 
             // Next, we create the `animations` section of the data file.
             // First, we get the name of the sprite without the extension by

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ type SpriteSheetJSON = {
 };
 
 program
-    .version("0.2.2")
+    .version("0.3.0")
     .description("A CLI to create a spritesheet from a set of sprites.")
     .argument("<input...>", "The sprites to include in the spritesheet.")
     .option("-n, --name <name>", "The name of the generated spritesheet.")


### PR DESCRIPTION
- If the spritesheet input was sprites that were not in the current directory, their full path would be included (ex. `/Users/Bob/Documents/Assets/Adventurer/adventurer-walk-00.png`). This is not ideal since that full path would have to be used when referencing the sprite in the Pixi application. Sprites now are just the name of the sprite (ex `adventurer-walk-00`).
- Fixed an issue where trimmed sprites were generated after the sprite sizes were calculated leading to incorrect sprite sizing and positioning in the JSON data file.