### PR TITLE
use ceil to make sure that tiled sheets are large enough

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ program
         // Determines what to pass to the `-tiled` option.
         const spriteCount = input.length;
         const columns = parseInt(options.columns);
-        const tiles = `${options.columns}x${Math.round(spriteCount / columns)}`;
+        const tiles = `${options.columns}x${Math.ceil(spriteCount / columns)}`;
 
         // Keeps track of the position where each sprite should be placed in
         // the `map` function below.


### PR DESCRIPTION
using round for the tile calculation could result in rounding down which makes imagemagick output two images rather than one image with all sprites tiles correctly 